### PR TITLE
Migrated to API v2!

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "2",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "vscode-projects",
   "description": "Integrates with VSCode Git Projects extension allowing you to open your projects from anywhere using Ulauncher",
   "developer_name": "Bruno Paz",
@@ -8,7 +7,8 @@
   "options": {
     "query_debounce": 0.1
   },
-  "preferences": [{
+  "preferences": [
+    {
       "id": "kw",
       "type": "keyword",
       "name": "VSCode Projects",
@@ -19,7 +19,7 @@
       "type": "input",
       "name": "Projects File path",
       "description": "Thr location of of projects file cache created by Project Manager VSCode Extension",
-      "default_value": "~/.config/Code/User/projects_cache_git.json"
+      "default_value": "~/.config/Code/User/globalStorage/alefragnani.project-manager/projects.json"
     }
   ]
 }

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "api-v1-release" },
+  { "required_api_version": "^2.0.0", "commit": "master" }
+]


### PR DESCRIPTION
I've added branch `api-v1-release`, as per ulaunchers migration guide. It's identical to the previous master (API v1), plus working default value.
Please do a `git fetch git@github.com:therj/ulauncher-vscode-projects.git api-v1-release:api-v1-release`.