### PR TITLE
Load all project.json files

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,9 +36,9 @@ class KeywordQueryEventListener(EventListener):
         """ Handles the event """
         items = []
 
-        if not os.path.exists(
-                os.path.expanduser(
-                    extension.preferences['projects_file_path'])):
+        full_project_path = os.path.expanduser(extension.preferences['projects_file_path'])
+
+        if not os.path.exists(full_project_path):
             return RenderResultListAction([
                 ExtensionResultItem(
                     icon='images/icon.png',
@@ -47,10 +47,16 @@ class KeywordQueryEventListener(EventListener):
                     on_enter=HideWindowAction())
             ])
 
-        with open(
-                os.path.expanduser(
-                    extension.preferences['projects_file_path'])) as projects_file:
-            projects = json.load(projects_file)
+        if os.path.isfile(full_project_path):
+            with open(full_project_path) as projects_file:
+                projects = json.load(projects_file)
+        else:
+            project_files = os.listdir(full_project_path)
+            projects = []
+            for projects_file in project_files:
+                projects_file = os.path.join(full_project_path, projects_file)
+                with open(projects_file) as file:
+                    projects += json.load(file)
 
         query = event.get_argument()
         if query:

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
       "type": "input",
       "name": "Projects File path",
       "description": "The location of of projects file cache created by Project Manager VSCode Extension",
-      "default_value": "~/.config/Code/User/globalStorage/alefragnani.project-manager/projects_cache_git.json"
+      "default_value": "~/.config/Code/User/globalStorage/alefragnani.project-manager/"
     },
     {
       "id": "code_executable_path",


### PR DESCRIPTION
This will allow the extension to load all project files in the VSCode projects directory not just one. This way if you have a mix of git, hg, and custom projects they will all be accessible