### PR TITLE
scaning for workdir if projects file not exists

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,12 +58,16 @@ class KeywordQueryEventListener(EventListener):
         items = []
 
         full_project_path = os.path.expanduser(extension.preferences['projects_file_path'])
-
+        query = event.get_argument()
         if not os.path.exists(full_project_path):
             workspaceDir = readWorkspaces()
+            if query:
+                workspaceDir = [
+                    x for x in workspaceDir
+                    if query.strip().lower() in x['name'].lower()
+                ]
             if len(workspaceDir) > 0:
                 for item in workspaceDir[:8]:
-                    print(item)
                     items.append(
                     ExtensionResultItem(icon='images/icon.png',
                                         name=item['name'],
@@ -91,7 +95,6 @@ class KeywordQueryEventListener(EventListener):
                 with open(projects_file) as file:
                     projects += json.load(file)
 
-        query = event.get_argument()
         if query:
             projects = [
                 x for x in projects


### PR DESCRIPTION
vs code stores recent workspaces(ctrl + r). I don't have project vs-code extension so I needed to load recent workspaces to access.
I don't know python well-enough but I did my best to update your extension.
feel free to refactor my code and merge it.

requirements :
- search on recent workspaces
- sort workspaces by recently opened!

I'll add features if I get free!

cheers,
MiladM