### PR TITLE
Launch projects with remote URLs correctly.

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,10 @@ class ItemEnterEventListener(EventListener):
         data = event.get_data()
 
         code_executable = extension.preferences['code_executable_path']
-        subprocess.run([code_executable, data['path']])
+        if not data['path'].startswith('vscode-remote://'):
+            subprocess.run([code_executable, data['path']])
+        else:
+            subprocess.run([code_executable, '--folder-uri', data['path']])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes an issue where projects that use [VS Code remote development](https://code.visualstudio.com/docs/remote/remote-overview) cannot be launched properly through the ULauncher plugin.

These projects have root folder paths such as `vscode-remote://ssh-remote+$host/$path` and for some reason only work when passed to `--folder-uri`.

I'm not convinced there's a reason not to always use `--folder-uri` but in the interests of not breaking anything I've only applied it to `data['path']`s that clearly match the pattern of VS Code remote URIs.