### PR TITLE
Allow to change config folder (e.g., Code - OSS)

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,8 +29,8 @@ class VSCodeProjectsExtension(Extension):
 
     def read_workspaces(self):
         """ Reads VS Code recent workspaces """
-        absPath = os.path.expanduser('~/.config/Code/User/workspaceStorage/')
-        fileList = glob.glob(absPath + "*/workspace.json")
+        absPath = os.path.expanduser(self.preferences['config_path'])
+        fileList = glob.glob(absPath + "/User/workspaceStorage/*/workspace.json")
         dirList = []
         for workspacePath in fileList:
             f = open(workspacePath, 'r')

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,13 @@
       "default_value": "vsp"
     },
     {
+      "id": "config_path",
+      "type": "input",
+      "name": "Config path",
+      "description": "The path to VSCode's config folder (e.g., update if you are using Code - OSS)",
+      "default_value": "~/.config/Code/"
+    },
+    {
       "id": "projects_file_path",
       "type": "input",
       "name": "Projects File path",


### PR DESCRIPTION
The path to recent workspaces was hard-coded. The open source version of VSCode (Code - OSS) has a different config path. This change also allows the extension to support custom config paths.