### PR TITLE
fix: use subprocess.Popen to avoid blocking due to the executable not…

### DIFF
--- a/vscode_projects/listeners/item_enter.py
+++ b/vscode_projects/listeners/item_enter.py
@@ -12,6 +12,6 @@ class ItemEnterEventListener(EventListener):
 
         code_executable = extension.preferences['code_executable_path']
         if not data['path'].startswith('vscode-remote://'):
-            subprocess.run([code_executable, data['path']])
+            subprocess.Popen([code_executable, data['path']])
         else:
-            subprocess.run([code_executable, '--folder-uri', data['path']])
+            subprocess.Popen([code_executable, '--folder-uri', data['path']])


### PR DESCRIPTION
I tried to reuse this plugin to open Cursor. Currently, there are some issues when opening Cursor from the command line on Ubuntu (refer to: https://github.com/getcursor/cursor/issues/1763), which causes Cursor to fail to return correctly upon startup.

- Using subprocess.run will block and wait for the command to return:

> Run the command described by args. Wait for command to complete, then return a CompletedProcess instance.
https://docs.python.org/3/library/subprocess.html#subprocess.run

- Using subprocess.Popen is non-blocking.

### TODO:
More comprehensive management of the object returned by Popen.